### PR TITLE
feat: Add floating WhatsApp button

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -94,6 +94,43 @@
     section {
       padding: 40px 20px;
     }
+
+    .floating-whatsapp-button {
+      position: fixed;
+      bottom: 20px;
+      right: 20px;
+      background-color: #25D366;
+      color: white;
+      padding: 15px;
+      border-radius: 50%;
+      text-align: center;
+      box-shadow: 2px 2px 10px rgba(0,0,0,0.2);
+      z-index: 1000;
+      text-decoration: none;
+      font-size: 1.2em; /* Adjusted for better visibility */
+    }
+
+    .floating-whatsapp-button:hover {
+      background-color: #1da851; /* Darker shade on hover */
+    }
+
+    @media (max-width: 768px) { /* For tablets and large phones */
+      .floating-whatsapp-button {
+        padding: 12px;
+        font-size: 1.1em;
+        bottom: 15px;
+        right: 15px;
+      }
+    }
+
+    @media (max-width: 480px) { /* For smaller mobile phones */
+      .floating-whatsapp-button {
+        padding: 10px;    /* Make the button smaller */
+        font-size: 1em;     /* Make the text smaller */
+        bottom: 15px;       /* Keep some distance from the bottom edge */
+        right: 15px;        /* Keep some distance from the right edge */
+      }
+    }
   </style>
 </head>
 <body>
@@ -148,5 +185,9 @@
       console.error('AOS library failed to load.');
     }
   </script>
+
+  <a href="https://wa.me/18298352169" target="_blank" class="floating-whatsapp-button">
+    WhatsApp
+  </a>
 </body>
 </html>


### PR DESCRIPTION
Integrates a floating WhatsApp button on the page.

The button is styled to be persistently visible in the bottom-right corner of the screen, providing you with an easy and constant way to initiate a WhatsApp chat.

Key changes:
- Added HTML for the floating button in Index.html.
- Applied CSS for positioning, appearance (circular, green), and a hover effect.
- Implemented CSS media queries to ensure responsiveness across different device screen sizes, adjusting padding, font-size, and position to prevent overlaps with other content.
- Verified the button correctly links to the specified WhatsApp number.
- The existing WhatsApp Call To Action button in the main content section has been retained.