### PR TITLE
fix: Increase floating WhatsApp button size on mobile

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -116,8 +116,8 @@
 
     @media (max-width: 768px) { /* For tablets and large phones */
       .floating-whatsapp-button {
-        padding: 12px;
-        font-size: 1.1em;
+        padding: 14px;    /* Increased padding */
+        font-size: 1.2em;   /* Increased font size */
         bottom: 15px;
         right: 15px;
       }
@@ -125,8 +125,8 @@
 
     @media (max-width: 480px) { /* For smaller mobile phones */
       .floating-whatsapp-button {
-        padding: 10px;    /* Make the button smaller */
-        font-size: 1em;     /* Make the text smaller */
+        padding: 14px;    /* Increased padding */
+        font-size: 1.1em;   /* Increased font size */
         bottom: 15px;       /* Keep some distance from the bottom edge */
         right: 15px;        /* Keep some distance from the right edge */
       }


### PR DESCRIPTION
Addresses feedback that the floating WhatsApp button was too small and difficult to use on mobile devices.

The CSS for the `.floating-whatsapp-button` has been adjusted within media queries for smaller screen sizes (<= 768px and <= 480px) to increase its padding and font-size. This makes the button more prominent, visible, and easily tappable on mobile and tablet devices without requiring you to zoom in.